### PR TITLE
Populate the info panel for CSW-derived datasets without major changes to the panel itself

### DIFF
--- a/lib/Core/overrideProperty.js
+++ b/lib/Core/overrideProperty.js
@@ -2,6 +2,7 @@
 
 /*global require*/
 var defined = require('terriajs-cesium/Source/Core/defined');
+var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 /**
@@ -26,7 +27,7 @@ var overrideProperty = function(owner, propertyName, descriptor) {
     // Define the new property.
     knockout.defineProperty(owner, propertyName, descriptor);
 
-    if (defined(overridden)) {
+    if (definedNotNull(overridden)) {
         // Notify subscribers to the old property that it has changed.
         // This is a hacky way of getting most subscribers to now subscribe to the new property.
         overridden.notifySubscribers();

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -9,6 +9,7 @@ var CsvCatalogItem = require('./CsvCatalogItem');
 var GeoJsonCatalogItem = require('./GeoJsonCatalogItem');
 var inherit = require('../Core/inherit');
 var KmlCatalogItem = require('./KmlCatalogItem');
+var LegendUrl = require('../Map/LegendUrl');
 var TerriaError = require('../Core/TerriaError');
 var WebMapServiceCatalogGroup = require('./WebMapServiceCatalogGroup');
 var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
@@ -315,8 +316,8 @@ CswCatalogGroup.prototype._load = function() {
                 }
 
 
-                // maybe more than one url that results in a data layer here - so check for 
-                // the acceptable ones, store the others as downloadUrls that can be 
+                // maybe more than one url that results in a data layer here - so check for
+                // the acceptable ones, store the others as downloadUrls that can be
                 // displayed in the metadata summary for the layer
                 var downloadUrls = [], acceptableUrls = [], legendUrl;
                 for (var m = 0;m < uris.length; m++) {
@@ -336,20 +337,20 @@ CswCatalogGroup.prototype._load = function() {
                     downloadUrls.push({
                       url: url.toString(),
                       description: defined(url.description) ? url.description : url.name
-                    });  
+                    });
                   }
                 }
 
-                // Now process the list of acceptable urls and hand the metadata 
+                // Now process the list of acceptable urls and hand the metadata
                 // record and the downloadUrls to each data layer item we create
                 for (var j = 0; j < acceptableUrls.length; ++j) {
                   var uri = acceptableUrls[j];
-  
+
                   var group = that;
                   if (that.metadataGroups.length > 0) {
                     group = findGroup(that, that.metadataGroups, record);
                   }
-  
+
                   if (defined(group)) {
                     var catalogItem = createItemForUri(that, record, uri, downloadUrls, legendUrl);
                     if (defined(catalogItem)) {
@@ -371,7 +372,7 @@ CswCatalogGroup.prototype._load = function() {
     }
 
     function loadDomain() {
-        var getDomainUrl = cleanUrl(that.url) + '?service=CSW&version=2.0.2&request=GetDomain&propertyname='+that.domainSpecification.domainPropertyName;  
+        var getDomainUrl = cleanUrl(that.url) + '?service=CSW&version=2.0.2&request=GetDomain&propertyname='+that.domainSpecification.domainPropertyName;
         return loadXML(proxyUrl(that.terria, getDomainUrl)).then(function(xml) {
           if (!xml || !xml.documentElement || (xml.documentElement.localName !== 'GetDomainResponse')) {
             throw new TerriaError({
@@ -387,8 +388,8 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
           var json = xml2json(xml), listOfValues = json.DomainValues.ListOfValues.Value;
           for (var i = 0; i < listOfValues.length; i++) {
             var keys = listOfValues[i].split(that.domainSpecification.hierarchySeparator);
-            // recursively find the group that the last key in keys should belong to and add that key 
-            findLevel(keys, 0, that.metadataGroups, that.domainSpecification.hierarchySeparator, that.domainSpecification.queryPropertyName); 
+            // recursively find the group that the last key in keys should belong to and add that key
+            findLevel(keys, 0, that.metadataGroups, that.domainSpecification.hierarchySeparator, that.domainSpecification.queryPropertyName);
           }
         }).otherwise(function(e) {
           throw new TerriaError({
@@ -458,14 +459,14 @@ function findLevel(keys, index, group, separator, queryField) {
     groupIndex = group.length - 1;
   }
   if (!defined(group[groupIndex].children)) group[groupIndex].children = [];
-  findLevel(keys, index+1, group[groupIndex].children, separator, queryField);  
+  findLevel(keys, index+1, group[groupIndex].children, separator, queryField);
 }
 
 function addMetadataGroup(keys, index, group, separator, queryField) {
 
   var value, regex = true;
   // if we aren't at the last key, use a regex and tack on another separator to avoid mismatches
-  if (index+1 !== keys.length) {  
+  if (index+1 !== keys.length) {
     var sepRegex = separator.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     value = "^" + keys.slice(0,index+1).join(sepRegex) + sepRegex;
   } else {
@@ -487,7 +488,7 @@ function findGroup(catalogGroup, keywordsGroups, record) {
       var kg = keywordsGroups[i];
       var fields = record[kg.field];
       var matched = false;
-      if (defined(fields)) { 
+      if (defined(fields)) {
         if (fields instanceof String || typeof fields === 'string') {
             fields = [ fields ];
         }
@@ -555,21 +556,29 @@ function createItemForUri(catalogGroup, record, uri, downloadUrls, legendUrl) {
         catalogItem.name = record.title;
         catalogItem.description = record.description;
         catalogItem.url = uri.toString();
-        catalogItem.metadataRecordUrl = catalogGroup.url + '?&version=2.0.2&service=CSW&request=GetRecordById&outputSchema=http://www.opengis.net/cat/csw/2.0.2&ElementSetName=full&id=' + record.identifier;
+        catalogItem.dataCustodian = '';
+
         if (defined(record.contributor)) {
-          catalogItem.mdDataCustodian = record.contributor.toString();
+            catalogItem.info.push({
+                name: 'Data Responsibility',
+                content: record.contributor.toString()
+            });
         }
-        catalogItem.downloadUrls = downloadUrls;
+
+        catalogItem.info.push({
+            name: 'Links',
+            content: downloadUrls.reduce(function(previousValue, downloadUrl) {
+                return previousValue + '[' + downloadUrl.description + '](' + downloadUrl.url + ')\n\n';
+            }, '')
+        });
+
+        catalogItem.info.push({
+            name: 'Metadata Record URL',
+            content: catalogGroup.url + '?&version=2.0.2&service=CSW&request=GetRecordById&outputSchema=http://www.opengis.net/cat/csw/2.0.2&ElementSetName=full&id=' + record.identifier
+        })
+
         if (defined(legendUrl)) {
-          catalogItem.legendUrl = legendUrl; // this used to be enough!!!
-          // this is to address a bug in LegendSectionViewModel which looks for legendUrls with
-          // this structure - probably WebMapServiceCatalogItem doesn't do this correctly
-          catalogItem.legendUrls = [{
-            url: legendUrl,
-            isImage: function() {
-              return true;
-            }
-          }];
+          catalogItem.legendUrl = new LegendUrl(legendUrl);
         }
 
         if (catalogItem.hasOwnProperty('layers') && defined(layerName)) {

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -131,6 +131,9 @@ var WebMapServiceCatalogItem = function(terria) {
             }
 
             return cleanUrl(this.url) + '?service=WMS&version=1.3.0&request=GetCapabilities';
+        },
+        set: function(value) {
+            this._getCapabilitiesUrl = value;
         }
     });
 

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -51,7 +51,7 @@ var WebMapServiceCatalogItem = function(terria) {
     this._allLayersInRawMetadata = undefined;
 
     this._metadata = undefined;
-    this._metadataUrl = undefined;
+    this._getCapabilitiesUrl = undefined;
     this._legendUrl = undefined;
     this._rectangle = undefined;
     this._rectangleFromMetadata = undefined;
@@ -111,24 +111,26 @@ var WebMapServiceCatalogItem = function(terria) {
     this.maxRefreshIntervals = 1000;
 
     knockout.track(this, [
-        '_metadataUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata',
+        '_getCapabilitiesUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata',
         'layers', 'parameters', 'getFeatureInfoFormats',
         'tilingScheme', 'populateIntervalsFromTimeDimension', 'minScaleDenominator']);
 
-    // metadataUrl and legendUrl are derived from url if not explicitly specified.
-    overrideProperty(this, 'metadataUrl', {
-        get : function() {
-            if (defined(this._metadataUrl)) {
-                return this._metadataUrl;
+    // getCapabilitiesUrl and legendUrl are derived from url if not explicitly specified.
+    overrideProperty(this, 'getCapabilitiesUrl', {
+        get: function() {
+            if (defined(this._getCapabilitiesUrl)) {
+                return this._getCapabilitiesUrl;
             }
+
+            if (defined(this.metadataUrl)) {
+                return this.metadataUrl;
+            }
+
             if (!defined(this.url)) {
                 return undefined;
             }
 
             return cleanUrl(this.url) + '?service=WMS&version=1.3.0&request=GetCapabilities';
-        },
-        set : function(value) {
-            this._metadataUrl = value;
         }
     });
 
@@ -276,9 +278,10 @@ freezeObject(WebMapServiceCatalogItem.defaultUpdaters);
 WebMapServiceCatalogItem.defaultSerializers = clone(ImageryLayerCatalogItem.defaultSerializers);
 
 // Serialize the underlying properties instead of the public views of them.
-WebMapServiceCatalogItem.defaultSerializers.metadataUrl = function(wmsItem, json, propertyName) {
-    json.metadataUrl = wmsItem._metadataUrl;
+WebMapServiceCatalogItem.defaultSerializers.getCapabilitiesUrl = function(wmsItem, json, propertyName) {
+    json.getCapabilitiesUrl = wmsItem._getCapabilitiesUrl;
 };
+
 WebMapServiceCatalogItem.defaultSerializers.tilingScheme = function(wmsItem, json, propertyName) {
     if (wmsItem.tilingScheme instanceof GeographicTilingScheme) {
         json.tilingScheme = 'geographic';
@@ -384,7 +387,9 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
         updateInfoSection(this, overwrite, 'Access Constraints', service.AccessConstraints);
     }
 
-    updateValue(this, overwrite, 'dataCustodian', getDataCustodian(capabilities));
+    updateInfoSection(this, overwrite, 'Service Contact', getServiceContactInformation(capabilities));
+    updateInfoSection(this, overwrite, 'GetCapabilities URL', this.getCapabilitiesUrl);
+
     updateValue(this, overwrite, 'minScaleDenominator', thisLayer.MinScaleDenominator);
     updateValue(this, overwrite, 'getFeatureInfoFormats', getFeatureInfoFormats(capabilities));
     updateValue(this, overwrite, 'rectangle', getRectangleFromLayers(this._allLayersInRawMetadata));
@@ -441,7 +446,7 @@ WebMapServiceCatalogItem.prototype._load = function() {
     var promises = [];
 
     if (!defined(this._rawMetadata)) {
-        promises.push(loadXML(proxyCatalogItemUrl(this, this.metadataUrl)).then(function(xml) {
+        promises.push(loadXML(proxyCatalogItemUrl(this, this.getCapabilitiesUrl)).then(function(xml) {
             var metadata = capabilitiesXmlToJson(xml);
             that.updateFromCapabilities(metadata, false);
         }));
@@ -936,7 +941,7 @@ function updateParentReference(capabilitiesJson, parent) {
     }
 }
 
-function getDataCustodian(capabilities) {
+function getServiceContactInformation(capabilities) {
     if (defined(capabilities.Service.ContactInformation)) {
         var contactInfo = capabilities.Service.ContactInformation;
 

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -52,33 +52,24 @@
             <!-- /ko -->
 
 
-						<!-- mdDataCustodian is the data custodian from the metadata -->
-            <!-- ko if: catalogItem.mdDataCustodian -->
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.mdDataCustodian && catalogItem.mdDataCustodian.length > 0">
-                <h2>Data Responsibility</h2>
-                <div class="catalog-item-info-description" data-bind="markdown: catalogItem.mdDataCustodian"></div>
+            <!-- ko foreach: sortedInfo -->
+                <!-- ko if: content && content.length > 0 -->
+                    <div class="catalog-item-info-section">
+                        <h2 data-bind="text: name"></h2>
+                        <div class="catalog-item-info-description">
+                            <div data-bind="markdown: content"></div>
+                        </div>
+                    </div>
+                <!-- /ko -->
+            <!-- /ko -->
+
+            <!-- ko if: catalogItem.dataCustodian -->
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataCustodian && catalogItem.dataCustodian.length > 0">
+                <h2>Data Custodian</h2>
+                <div class="catalog-item-info-description" data-bind="markdown: catalogItem.dataCustodian"></div>
             </div>
             <!-- /ko -->
 
-						<!-- downloadUrls is a list of download links from the metadata -->
-            <!-- ko if: catalogItem.downloadUrls -->
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.downloadUrls && catalogItem.downloadUrls.length > 0">
-                <h2>Links</h2>
-            		<!-- ko foreach: catalogItem.downloadUrls -->
-                <div class="catalog-item-info-description">
-                	<a data-bind="attr: { href: url }, text: description" target="_blank"></a>
-								</div>
-            		<!-- /ko -->
-            </div>
-            <!-- /ko -->
-
-						<!-- if we have a link to the metadata record in a catalogue then show it -->
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.metadataRecordUrl">
-                <h2>Metadata URL</h2>
-                <a data-bind="attr: { href: catalogItem.metadataRecordUrl }, text: catalogItem.metadataRecordUrl" target="_blank"></a>
-            </div>
-
-						<!-- Now spit out the rest of the WMS stuff - can be pretty sparse -->
             <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
                 <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>
                 <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wms'">
@@ -98,110 +89,87 @@
                     <span class="catalog-item-info-tech-attributes" data-bind="text: catalogItem.typeNames"></span>
                 </p>
             </div>
-            		<!-- ko foreach: sortedInfo -->
-                <!-- ko if: content && content.length > 0 -->
-                    <div class="catalog-item-info-section">
-                        <h2 data-bind="text: name"></h2>
-                        <div class="catalog-item-info-description">
-                            <div data-bind="markdown: content"></div>
-                        </div>
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.metadataUrl">
+                <h2>Metadata URL</h2>
+                <a class="catalog-item-info-description" data-bind="attr: { href: catalogItem.metadataUrl }, text: catalogItem.metadataUrl" target="_blank"></a>
+            </div>
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'">
+                <h2>Data URL</h2>
+                <div class="catalog-item-info-description">
+                    Use the link below to download the data.  See the
+                    <a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank">Web Feature Service (WFS) documentation</a>
+                    for more information on customising URL query parameters.
+                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
+                </div>
+            </div>
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wcs' || catalogItem.dataUrlType === 'wcs-complete'">
+                <h2>Data URL</h2>
+                <div class="catalog-item-info-description">
+                    Use the link below to download the data.  See the
+                    <a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank">Web Coverage Service (WCS) documentation</a>
+                    for more information on customising URL query parameters.
+                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
+                </div>
+            </div>
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'direct'">
+                <h2>Data URL</h2>
+                <div class="catalog-item-info-description">
+                    Use the link below to download data directly.
+                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
+                </div>
+            </div>
+            <div class="catalog-item-info-section">
+                <div class="catalog-item-info-details-heading" data-bind="click: toggleShowDataDetails">
+                    <button class="catalog-item-info-details-label">Data Source Details</button>
+                    <div class="catalog-item-info-details-expand-button-holder">
+                        <button href="#" class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showDataDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                    </div>
+                </div>
+                <!-- ko if: showDataDetails -->
+                    <div class="catalog-item-info-table">
+                        <!-- ko if: catalogItem.metadata.dataSourceMetadata.hasChildren -->
+                        <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.dataSourceMetadata.items }">
+                        </table>
+                        <!-- /ko -->
+                        <!-- ko if: catalogItem.metadata.dataSourceErrorMessage -->
+                        <table>
+                            <tr>
+                                <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
+                                    <div class="catalog-item-info-properties-arrow"></div>
+                                    <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.dataSourceErrorMessage"></div>
+                                </td>
+                            </tr>
+                        </table>
+                        <!-- /ko -->
                     </div>
                 <!-- /ko -->
-            		<!-- /ko -->
-
-								<!-- although this is called dataCustodian, in fact it is the person who is responsible
-								 		for the service that delivers the data -->
-            		<!-- ko if: catalogItem.dataCustodian -->
-            		<div class="catalog-item-info-section" data-bind="if: catalogItem.dataCustodian && catalogItem.dataCustodian.length > 0">
-                		<h2>Service Responsibility</h2>
-                		<div class="catalog-item-info-description" data-bind="markdown: catalogItem.dataCustodian"></div>
-            		</div>
-            		<!-- /ko -->
-
-								<!-- This is not a metadataUrl - it just a description of the service that delivers the
-						     		data -->
-            		<div class="catalog-item-info-section" data-bind="if: catalogItem.metadataUrl">
-                		<h2>Service Description URL</h2>
-                		<a data-bind="attr: { href: catalogItem.metadataUrl }, text: catalogItem.metadataUrl" target="_blank"></a>
-            		</div>
-            		<div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'">
-                		<h2>Data URL</h2>
-                		<div class="catalog-item-info-description">
-                    		Use the link below to download the data.  See the
-                    		<a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank">Web Feature Service (WFS) documentation</a>
-                    		for more information on customising URL query parameters.
-                    		<div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
-                		</div>
-            		</div>
-            		<div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wcs' || catalogItem.dataUrlType === 'wcs-complete'">
-                		<h2>Data URL</h2>
-                		<div class="catalog-item-info-description">
-                    		Use the link below to download the data.  See the
-                    		<a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank">Web Coverage Service (WCS) documentation</a>
-                    		for more information on customising URL query parameters.
-                    		<div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
-                		</div>
-            		</div>
-            		<div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'direct'">
-                		<h2>Data URL</h2>
-                		<div class="catalog-item-info-description">
-                    		Use the link below to download data directly.
-                    		<div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
-                		</div>
-            		</div>
-            		<div class="catalog-item-info-section">
-                		<div class="catalog-item-info-details-heading" data-bind="click: toggleShowDataDetails">
-                    		<button class="catalog-item-info-details-label">WMS Layer Details</button>
-                    		<div class="catalog-item-info-details-expand-button-holder">
-                        		<button href="#" class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showDataDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
-                    		</div>
-                		</div>
-                		<!-- ko if: showDataDetails -->
-                    		<div class="catalog-item-info-table">
-                        		<!-- ko if: catalogItem.metadata.dataSourceMetadata.hasChildren -->
-                        		<table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.dataSourceMetadata.items }">
-                        		</table>
-                        		<!-- /ko -->
-                        		<!-- ko if: catalogItem.metadata.dataSourceErrorMessage -->
-                        		<table>
-                            		<tr>
-                                		<td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
-                                    		<div class="catalog-item-info-properties-arrow"></div>
-                                    		<div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.dataSourceErrorMessage"></div>
-                                		</td>
-                            		</tr>
-                        		</table>
-                        		<!-- /ko -->
-                    		</div>
-                		<!-- /ko -->
-            		</div>
-            		<div class="catalog-item-info-section">
-                		<div class="catalog-item-info-details-heading" data-bind="click: toggleShowServiceDetails">
-                    		<button class="catalog-item-info-details-label">Service Details</button>
-                    		<div class="catalog-item-info-details-expand-button-holder">
-                        		<button class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showServiceDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
-                    		</div>
-                		</div>
-                		<!-- ko if: showServiceDetails -->
-                    		<div class="catalog-item-info-table">
-                        		<!-- ko if: catalogItem.metadata.serviceMetadata.hasChildren -->
-                        		<table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.serviceMetadata.items }">
-                        		</table>
-                        		<!-- /ko -->
-                        		<!-- ko if: catalogItem.metadata.serviceErrorMessage -->
-                        		<table>
-                            		<tr>
-                                		<td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
-                                    		<div class="catalog-item-info-properties-arrow"></div>
-                                    		<div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.serviceErrorMessage"></div>
-                                		</td>
-                            		</tr>
-                        		</table>
-                        		<!-- /ko -->
-                    		</div>
-                		<!-- /ko -->
-            		</div>
-						</div>
+            </div>
+            <div class="catalog-item-info-section">
+                <div class="catalog-item-info-details-heading" data-bind="click: toggleShowServiceDetails">
+                    <button class="catalog-item-info-details-label">Data Service Details</button>
+                    <div class="catalog-item-info-details-expand-button-holder">
+                        <button class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showServiceDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                    </div>
+                </div>
+                <!-- ko if: showServiceDetails -->
+                    <div class="catalog-item-info-table">
+                        <!-- ko if: catalogItem.metadata.serviceMetadata.hasChildren -->
+                        <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.serviceMetadata.items }">
+                        </table>
+                        <!-- /ko -->
+                        <!-- ko if: catalogItem.metadata.serviceErrorMessage -->
+                        <table>
+                            <tr>
+                                <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
+                                    <div class="catalog-item-info-properties-arrow"></div>
+                                    <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.serviceErrorMessage"></div>
+                                </td>
+                            </tr>
+                        </table>
+                        <!-- /ko -->
+                    </div>
+                <!-- /ko -->
+            </div>
         </div>
     </div>
     <div class="catalog-item-info-loading" data-bind="visible: catalogItem.metadata.isLoading">

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -129,15 +129,15 @@ describe('WebMapServiceCatalogItem', function() {
         });
     });
 
-    it('derives metadataUrl from url if metadataUrl is not explicitly provided', function() {
+    it('derives getCapabilitiesUrl from url if getCapabilitiesUrl is not explicitly provided', function() {
         wmsItem.url = 'http://foo.com/bar';
-        expect(wmsItem.metadataUrl.indexOf(wmsItem.url)).toBe(0);
+        expect(wmsItem.getCapabilitiesUrl.indexOf(wmsItem.url)).toBe(0);
     });
 
-    it('uses explicitly-provided metadataUrl', function() {
-        wmsItem.metadataUrl = 'http://foo.com/metadata';
+    it('uses explicitly-provided getCapabilitiesUrl', function() {
+        wmsItem.getCapabilitiesUrl = 'http://foo.com/metadata';
         wmsItem.url = 'http://foo.com/somethingElse';
-        expect(wmsItem.metadataUrl).toBe('http://foo.com/metadata');
+        expect(wmsItem.getCapabilitiesUrl).toBe('http://foo.com/metadata');
     });
 
     it('defaults to having no dataUrl', function() {
@@ -163,7 +163,7 @@ describe('WebMapServiceCatalogItem', function() {
             dataUrlType: 'wfs',
             dataUrl: 'http://my.wfs.com/wfs',
             dataCustodian: 'Data Custodian',
-            metadataUrl: 'http://my.metadata.com',
+            getCapabilitiesUrl: 'http://my.metadata.com',
             url: 'http://my.wms.com',
             layers: 'mylayer',
             parameters: {
@@ -181,7 +181,7 @@ describe('WebMapServiceCatalogItem', function() {
         expect(wmsItem.dataUrlType).toBe('wfs');
         expect(wmsItem.dataUrl.indexOf('http://my.wfs.com/wfs')).toBe(0);
         expect(wmsItem.dataCustodian).toBe('Data Custodian');
-        expect(wmsItem.metadataUrl).toBe('http://my.metadata.com');
+        expect(wmsItem.getCapabilitiesUrl).toBe('http://my.metadata.com');
         expect(wmsItem.url).toBe('http://my.wms.com');
         expect(wmsItem.layers).toBe('mylayer');
         expect(wmsItem.parameters).toEqual({


### PR DESCRIPTION
This is a tweak to #1270 to populate the info page from the CSW record mostly via the `CatalogItem.info` property, rather than making major changes to to the `CatalogItemInfo` UI itself.  This way the impact is limited to CSW-derived datasets rather than affecting everything.

I realize the metadata on the info panel is a bit of a mess in TerriaJS in the moment.  We might benefit from organizing it around a metadata standard (Dublin Core?) or something, but I think it's worthwhile to keep that "bigger problem" separate from the CSW grouping, which is the main point of #1270.

With these changes, the content of the info page for your layers is almost the same as what you implemented, even though I've reverted most of the changes to `CatalogItemInfo.html`.

Let me know what you think @sppigot.
